### PR TITLE
Make the first run explain itself, then cut the CLI to one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ There is one command and five flags.
 uv run rhfeed --selector 0x095ea7b3
 # one contract — this one is the chain's busiest router, so it shows something
 uv run rhfeed --to 0xcaf681a66d020601342297493863e78c959e5cb2
-# one wallet. Also prints who sent each transaction, which is the one expensive
-# field — see Speed. This was an active bot when we wrote it; wallets go quiet
+# one wallet — for an address you already care about, since it also prints who
+# sent each transaction, and that is the one expensive field. See Speed
 uv run rhfeed --sender 0x830d44e14a9388e5b1880902b8370b951b622b9c
 uv run rhfeed --json            # machine-readable, and the only place full addresses appear
 uv run rhfeed --seconds 30      # stop on a timer instead of Ctrl-C
@@ -77,8 +77,9 @@ uv run rhfeed --feed mainnet    # skip the relay, straight at the public endpoin
 `--to`, `--selector` and `--sender` can each be repeated, and they combine.
 
 Not sure what to filter on? `uv run python examples/replay_capture.py` decodes the
-frames bundled for the tests and prints the busiest contracts and selectors. No
-relay needed — it reads from disk.
+frames bundled for the tests and ranks the contracts, selectors and wallets in them.
+No relay needed — it reads from disk. A contract stays busy; a wallet may not, so
+check before you take one from there or from the example above.
 
 Done looking? `docker compose down` stops the relay — it is set to restart with
 Docker otherwise.
@@ -118,7 +119,7 @@ Worked examples:
 |---|---|
 | [`token_flow.py`](examples/token_flow.py) | watch specific tokens — the cheap-filter pattern, start here. Its default (NVDA) is a thin market, so expect long gaps between matches; it prints a scan line every 15s so you can tell idle from broken |
 | [`copy_trade_signals.py`](examples/copy_trade_signals.py) | follow wallets, emit JSON signals — takes the addresses to follow as arguments |
-| [`replay_capture.py`](examples/replay_capture.py) | run the same decoder offline against saved frames — no relay, no network |
+| [`replay_capture.py`](examples/replay_capture.py) | run the same decoder offline against saved frames — no relay, no network. Ranks contracts, selectors and wallets, and times the sender recoveries so the cost is visible |
 | [`bench.py`](examples/bench.py) | reproduce the numbers in the next section on your hardware |
 
 ## Read this before you trade on it

--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ memory and ~1.6% of a core, nothing written to disk. It is *not* a full node.
 ## Filter it
 
 ```bash
-uv run rhfeed watch --selector 0x095ea7b3     # ERC-20 approvals only
-uv run rhfeed watch --to 0xcaf681a6...        # one contract
-uv run rhfeed watch --sender 0xabc...         # one wallet
+# ERC-20 approvals only
+uv run rhfeed watch --selector 0x095ea7b3
+# one contract — this one is the chain's busiest router, so it shows something
+uv run rhfeed watch --to 0xcaf681a66d020601342297493863e78c959e5cb2
+# one wallet, which costs a signature recovery per transaction. This one was an
+# active bot when we wrote this; wallets go quiet, contracts mostly don't
+uv run rhfeed watch --sender 0x830d44e14a9388e5b1880902b8370b951b622b9c
 uv run rhfeed watch --min-value 1000000000000000000   # ≥ 1 ETH
 uv run rhfeed watch --sender-column           # show who sent each tx
 uv run rhfeed watch --json                    # machine-readable, full addresses
@@ -80,7 +84,19 @@ Skipping the relay for a one-off look is `--feed mainnet` (or `testnet`, or any
 Nitro relay URL), which works on either side of the subcommand. Fine for a look,
 not for anything that runs — that's what the rate limit above is about.
 
+Done looking? `docker compose down` stops the relay — it is set to restart with
+Docker otherwise.
+
 ## Use it from Python
+
+In your own project, not this checkout:
+
+```bash
+uv add git+https://github.com/chainstacklabs/robinhood-chain-sequencer-feed
+```
+
+It still expects a relay on `ws://127.0.0.1:9642`; copy
+[`docker-compose.yml`](docker-compose.yml) or pass a URL to `FeedConsumer(...)`.
 
 ```python
 import asyncio
@@ -105,7 +121,7 @@ Worked examples:
 | | |
 |---|---|
 | [`token_flow.py`](examples/token_flow.py) | watch specific tokens — the cheap-filter pattern, start here. Its default (NVDA) is a thin market, so expect long gaps between matches; it prints a scan line every 15s so you can tell idle from broken |
-| [`copy_trade_signals.py`](examples/copy_trade_signals.py) | follow wallets, emit JSON signals |
+| [`copy_trade_signals.py`](examples/copy_trade_signals.py) | follow wallets, emit JSON signals — takes the addresses to follow as arguments |
 | [`replay_capture.py`](examples/replay_capture.py) | run the same code offline against a recording |
 | [`bench.py`](examples/bench.py) | reproduce the numbers in the next section on your hardware |
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,24 @@ the part underneath it: get the data, decode it fast, hand it over.
 
 ## Try it
 
-You need Docker and Python 3.11+.
+You need Docker and [uv](https://docs.astral.sh/uv/getting-started/installation/),
+which fetches its own Python 3.11+.
 
 ```bash
-docker compose up -d relay    # give it ~20s to connect
+docker compose up -d --wait relay   # --wait blocks until the relay is serving
 uv sync
-uv run rhfeed watch           # Ctrl-C to stop
+uv run rhfeed watch                 # Ctrl-C to stop
 ```
 
-That's it. Columns are `hash · kind · to · selector`, grouped by block.
+That's it. Columns are `hash · kind · to · selector`, grouped by block. Addresses are
+shortened to keep the line readable; `--json` gives the full ones, which is what you
+want if you are about to filter on them.
+
+**Nothing showing up?** `rhfeed` tells you which kind of nothing it is, on stderr: it
+says when it connects, when the backlog drains, when it can't reach the relay, and
+when it's connected but no frames are arriving. That last one means the relay's own
+upstream is down — `docker compose logs relay` prints `Feed connected` when that link
+is healthy and retries `failed connect to sequencer broadcast` when it isn't.
 
 **Why the Docker step?** That's Offchain Labs' official relay — one connection to
 Robinhood's feed, re-served to as many local consumers as you like. You want it
@@ -56,7 +65,8 @@ uv run rhfeed watch --to 0xcaf681a6...        # one contract
 uv run rhfeed watch --sender 0xabc...         # one wallet
 uv run rhfeed watch --min-value 1000000000000000000   # ≥ 1 ETH
 uv run rhfeed watch --sender-column           # show who sent each tx
-uv run rhfeed watch --json                    # machine-readable
+uv run rhfeed watch --json                    # machine-readable, full addresses
+uv run rhfeed watch --seconds 30              # stop on a timer, not on Ctrl-C
 ```
 
 Not sure what to filter on? Record a minute and see what's actually busy:
@@ -65,6 +75,10 @@ Not sure what to filter on? Record a minute and see what's actually busy:
 uv run rhfeed capture --seconds 60 session.jsonl
 uv run python examples/replay_capture.py session.jsonl
 ```
+
+Skipping the relay for a one-off look is `--feed mainnet` (or `testnet`, or any
+Nitro relay URL), which works on either side of the subcommand. Fine for a look,
+not for anything that runs — that's what the rate limit above is about.
 
 ## Use it from Python
 
@@ -86,13 +100,14 @@ async def main():
 asyncio.run(main())
 ```
 
-Three worked examples:
+Worked examples:
 
 | | |
 |---|---|
-| [`token_flow.py`](examples/token_flow.py) | watch specific tokens — the cheap-filter pattern, start here |
+| [`token_flow.py`](examples/token_flow.py) | watch specific tokens — the cheap-filter pattern, start here. Its default (NVDA) is a thin market, so expect long gaps between matches; it prints a scan line every 15s so you can tell idle from broken |
 | [`copy_trade_signals.py`](examples/copy_trade_signals.py) | follow wallets, emit JSON signals |
 | [`replay_capture.py`](examples/replay_capture.py) | run the same code offline against a recording |
+| [`bench.py`](examples/bench.py) | reproduce the numbers in the next section on your hardware |
 
 ## Read this before you trade on it
 
@@ -126,6 +141,10 @@ want:
 The last three are computed only when you read them, then cached. So if you filter
 on the cheap fields, a transaction you discard costs ~4 µs instead of ~70.
 
+Don't take the table's word for it — `uv run python examples/bench.py` prints these
+four rows for your machine, and `--reference` adds the libraries the fast paths
+replace.
+
 Headroom is generous either way: the chain does ~71 transactions a second, and one
 core fully decodes ~14,000.
 
@@ -144,6 +163,7 @@ on transactions of every type and on 143 real ones captured from mainnet:
 
 ```bash
 uv run --extra dev pytest
+uv run --extra dev python examples/bench.py --reference   # the same comparison, timed
 ```
 
 ## Endpoints

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ which fetches its own Python 3.11+.
 ```bash
 docker compose up -d --wait relay   # --wait blocks until the relay is serving
 uv sync
-uv run rhfeed watch                 # Ctrl-C to stop
+uv run rhfeed                       # Ctrl-C to stop
 ```
 
 That's it. Columns are `hash · kind · to · selector`, grouped by block. Addresses are
@@ -59,30 +59,26 @@ memory and ~1.6% of a core, nothing written to disk. It is *not* a full node.
 
 ## Filter it
 
+There is one command and five flags.
+
 ```bash
 # ERC-20 approvals only
-uv run rhfeed watch --selector 0x095ea7b3
+uv run rhfeed --selector 0x095ea7b3
 # one contract — this one is the chain's busiest router, so it shows something
-uv run rhfeed watch --to 0xcaf681a66d020601342297493863e78c959e5cb2
-# one wallet, which costs a signature recovery per transaction. This one was an
-# active bot when we wrote this; wallets go quiet, contracts mostly don't
-uv run rhfeed watch --sender 0x830d44e14a9388e5b1880902b8370b951b622b9c
-uv run rhfeed watch --min-value 1000000000000000000   # ≥ 1 ETH
-uv run rhfeed watch --sender-column           # show who sent each tx
-uv run rhfeed watch --json                    # machine-readable, full addresses
-uv run rhfeed watch --seconds 30              # stop on a timer, not on Ctrl-C
+uv run rhfeed --to 0xcaf681a66d020601342297493863e78c959e5cb2
+# one wallet. Also prints who sent each transaction, which is the one expensive
+# field — see Speed. This was an active bot when we wrote it; wallets go quiet
+uv run rhfeed --sender 0x830d44e14a9388e5b1880902b8370b951b622b9c
+uv run rhfeed --json            # machine-readable, and the only place full addresses appear
+uv run rhfeed --seconds 30      # stop on a timer instead of Ctrl-C
+uv run rhfeed --feed mainnet    # skip the relay, straight at the public endpoint
 ```
 
-Not sure what to filter on? Record a minute and see what's actually busy:
+`--to`, `--selector` and `--sender` can each be repeated, and they combine.
 
-```bash
-uv run rhfeed capture --seconds 60 session.jsonl
-uv run python examples/replay_capture.py session.jsonl
-```
-
-Skipping the relay for a one-off look is `--feed mainnet` (or `testnet`, or any
-Nitro relay URL), which works on either side of the subcommand. Fine for a look,
-not for anything that runs — that's what the rate limit above is about.
+Not sure what to filter on? `uv run python examples/replay_capture.py` decodes the
+frames bundled for the tests and prints the busiest contracts and selectors. No
+relay needed — it reads from disk.
 
 Done looking? `docker compose down` stops the relay — it is set to restart with
 Docker otherwise.
@@ -122,7 +118,7 @@ Worked examples:
 |---|---|
 | [`token_flow.py`](examples/token_flow.py) | watch specific tokens — the cheap-filter pattern, start here. Its default (NVDA) is a thin market, so expect long gaps between matches; it prints a scan line every 15s so you can tell idle from broken |
 | [`copy_trade_signals.py`](examples/copy_trade_signals.py) | follow wallets, emit JSON signals — takes the addresses to follow as arguments |
-| [`replay_capture.py`](examples/replay_capture.py) | run the same code offline against a recording |
+| [`replay_capture.py`](examples/replay_capture.py) | run the same decoder offline against saved frames — no relay, no network |
 | [`bench.py`](examples/bench.py) | reproduce the numbers in the next section on your hardware |
 
 ## Read this before you trade on it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 # Offchain Labs' own relay binary, pointed at Robinhood Chain.
 #
 #   docker compose up -d --wait relay     # blocks until the relay is serving
-#   rhfeed watch
+#   rhfeed
 #
-# If it never becomes healthy, or it is healthy and `rhfeed watch` still shows
+# If it never becomes healthy, or it is healthy and `rhfeed` still shows
 # nothing, the answer is in `docker compose logs relay` — "Feed connected" means the
 # upstream is good, repeated "failed connect to sequencer broadcast" means it is not.
 #
@@ -36,7 +36,7 @@ services:
     # treats a 400 as success, which is what we want here.
     #
     # This says the local server is up. It does *not* say the upstream feed is
-    # connected — nothing the relay exposes does. `rhfeed watch` warns about that
+    # connected — nothing the relay exposes does. `rhfeed` warns about that
     # case itself after 30 quiet seconds.
     healthcheck:
       test: ["CMD", "curl", "-s", "-o", "/dev/null", "--max-time", "3", "http://127.0.0.1:9642/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 # Offchain Labs' own relay binary, pointed at Robinhood Chain.
 #
-#   docker compose up -d relay
+#   docker compose up -d --wait relay     # blocks until the relay is serving
 #   rhfeed watch
+#
+# If it never becomes healthy, or it is healthy and `rhfeed watch` still shows
+# nothing, the answer is in `docker compose logs relay` — "Feed connected" means the
+# upstream is good, repeated "failed connect to sequencer broadcast" means it is not.
 #
 # `entrypoint: relay` selects a different binary from the nitro-node image: it holds
 # one upstream WebSocket and re-serves it, with no sync, no execution and no
@@ -27,3 +31,16 @@ services:
       - --chain.id=4663
     # The relay holds everything in memory and needs very little of it.
     mem_limit: 512m
+    # The broadcaster answers a plain GET with "400 handshake error: bad Upgrade
+    # header", which is enough to prove it is listening and serving. curl without -f
+    # treats a 400 as success, which is what we want here.
+    #
+    # This says the local server is up. It does *not* say the upstream feed is
+    # connected — nothing the relay exposes does. `rhfeed watch` warns about that
+    # case itself after 30 quiet seconds.
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-o", "/dev/null", "--max-time", "3", "http://127.0.0.1:9642/"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -1,0 +1,129 @@
+"""Reproduce the Speed table in the README on your own hardware.
+
+    uv run python examples/bench.py                  # against tests/frames.jsonl
+    uv run python examples/bench.py session.jsonl    # against your own capture
+
+Each row decodes every transaction in the capture and reads one more field than the
+row above it, so the differences are what that field costs. The absolute numbers are
+your machine's; the ratios are the point, and they are why `hash`, `to` and `sender`
+are lazy instead of computed up front.
+
+Add --reference (needs the dev extra) to time the libraries the fast paths replace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from rhfeed import parse_frame
+from rhfeed.codec import decode_transaction
+
+DEFAULT_CAPTURE = Path(__file__).resolve().parent.parent / "tests" / "frames.jsonl"
+
+
+def load(path: Path) -> list[bytes]:
+    """Every transaction envelope in a capture, as raw bytes."""
+    raws: list[bytes] = []
+    for line in path.read_text().splitlines():
+        if line.strip():
+            for msg in parse_frame(json.loads(line)):
+                raws.extend(tx.raw for tx in msg.txs)
+    return raws
+
+
+def best_of(fn, raws: list[bytes], rounds: int) -> float:
+    """Microseconds per transaction, best round.
+
+    Best rather than mean: we are measuring how long the work takes, and every
+    source of noise on a shared machine only ever adds time.
+    """
+    best = float("inf")
+    for _ in range(rounds):
+        started = time.perf_counter()
+        fn(raws)
+        best = min(best, (time.perf_counter() - started) / len(raws))
+    return best * 1e6
+
+
+def cheap(raws):
+    for tx in map(decode_transaction, raws):
+        _ = tx.to_bytes, tx.selector, tx.value, tx.nonce, tx.gas
+
+
+def with_hash(raws):
+    for tx in map(decode_transaction, raws):
+        _ = tx.to_bytes, tx.selector, tx.hash
+
+
+def with_to(raws):
+    for tx in map(decode_transaction, raws):
+        _ = tx.to_bytes, tx.selector, tx.hash, tx.to
+
+
+def with_sender(raws):
+    for tx in map(decode_transaction, raws):
+        _ = tx.to_bytes, tx.selector, tx.hash, tx.to, tx.sender
+
+
+ROWS = [
+    ("to_bytes, selector, value, nonce, gas", cheap, 20),
+    ("+ hash", with_hash, 20),
+    ("+ to (checksummed)", with_to, 20),
+    ("+ sender", with_sender, 5),
+]
+
+
+def reference(raws: list[bytes]) -> None:
+    """The libraries the hand-written paths replace, for the 2x / 5x claims."""
+    try:
+        import rlp
+        from eth_account import Account
+    except ImportError:
+        sys.exit("rhfeed: --reference needs the dev extra:  uv run --extra dev python ...")
+
+    legacy = [r for r in raws if r and r[0] >= 0x80]
+    print(f"\nreference implementations ({len(raws)} tx, {len(legacy)} of them legacy)")
+    print(
+        f"  eth_account.recover_transaction      "
+        f"{best_of(lambda rs: [Account.recover_transaction(r) for r in rs], raws, 3):8.1f} us/tx"
+    )
+    if legacy:
+        print(
+            f"  rlp.decode (legacy envelopes only)   "
+            f"{best_of(lambda rs: [rlp.decode(r) for r in rs], legacy, 20):8.1f} us/tx"
+        )
+        print(f"  rhfeed scan (legacy envelopes only)  {best_of(cheap, legacy, 20):8.1f} us/tx")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("capture", nargs="?", type=Path, default=DEFAULT_CAPTURE)
+    ap.add_argument("--reference", action="store_true", help="also time eth-account and rlp")
+    args = ap.parse_args()
+
+    if not args.capture.exists():
+        sys.exit(f"rhfeed: no such capture: {args.capture}")
+    raws = load(args.capture)
+    if not raws:
+        sys.exit(f"rhfeed: {args.capture} contained no transactions")
+
+    print(f"{len(raws)} transactions from {args.capture}\n")
+    print(f"{'what you read':<40}{'per tx':>10}")
+    for label, fn, rounds in ROWS:
+        print(f"{label:<40}{best_of(fn, raws, rounds):>7.1f} us")
+
+    per_core = 1e6 / best_of(with_sender, raws, 5)
+    print(f"\none core, full decode including sender: ~{per_core:,.0f} tx/s")
+
+    if args.reference:
+        reference(raws)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/replay_capture.py
+++ b/examples/replay_capture.py
@@ -5,8 +5,14 @@
 
 Same decoder, no network, no relay. Whatever you write against `FeedConsumer` runs
 unchanged here, which is how you test it against known traffic first. This prints a
-profile of what the frames contained — the quickest way to find out which contracts
-and selectors are worth filtering on.
+profile of what the frames contained — the quickest way to find out which contracts,
+selectors and wallets are worth filtering on.
+
+Note which tallies are cheap and which is not. Contracts and selectors come from
+bytes the decoder already sliced out. Senders do not exist in a transaction and have
+to be recovered from the signature, one at a time, at roughly fifteen times the cost
+of everything else together. Offline that only means waiting; on a live stream it is
+the thing you arrange not to do, which is why `Tx.sender` is lazy.
 
 Saving your own is four lines of `websockets`: connect to the relay and write each
 raw message to a file, one per line. That is exactly the format read here, and how
@@ -17,6 +23,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from collections import Counter
 from pathlib import Path
 
@@ -28,9 +35,16 @@ BUNDLED = Path(__file__).resolve().parent.parent / "tests" / "frames.jsonl"
 def main(path: str) -> None:
     selectors: Counter[str] = Counter()
     recipients: Counter[str] = Counter()
+    senders: Counter[str] = Counter()
     types: Counter[int] = Counter()
     blocks = txs = deploys = 0
     from_parent = 0
+    recovery_seconds = 0.0
+    recovered = 0
+    # coincurve builds its signing context on the first call, which costs ~16 ms
+    # once. Averaged over a small capture that swamps the real per-transaction cost,
+    # so the first recovery is excluded from the timing rather than the tally.
+    warmed = False
 
     with open(path) as fh:
         for line in fh:
@@ -42,6 +56,19 @@ def main(path: str) -> None:
                 for tx in msg.txs:
                     txs += 1
                     types[tx.tx_type] += 1
+
+                    # The expensive one, timed so the cost is visible rather than
+                    # asserted. Live code recovers a sender only for the few
+                    # transactions that survive a cheap filter.
+                    started = time.perf_counter()
+                    sender = tx.sender_bytes
+                    if warmed:
+                        recovery_seconds += time.perf_counter() - started
+                        recovered += 1
+                    warmed = True
+                    if sender:
+                        senders[sender.hex()] += 1
+
                     if tx.to_bytes is None:
                         deploys += 1
                         continue
@@ -62,6 +89,16 @@ def main(path: str) -> None:
     print("\nmost-used selectors")
     for selector, n in selectors.most_common(10):
         print(f"  0x{selector}  {n:>6}  {n / max(txs, 1):.1%}")
+
+    print("\nbusiest wallets — pass one of these to `rhfeed --sender`")
+    for address, n in senders.most_common(10):
+        print(f"  0x{address}  {n:>6}  {n / max(txs, 1):.1%}")
+    if recovered:
+        print(
+            f"\nrecovering {recovered} senders took {recovery_seconds * 1e3:.0f} ms, "
+            f"{recovery_seconds / recovered * 1e6:.0f} us each — the reason a live "
+            f"filter matches on `to` and `selector` first"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/replay_capture.py
+++ b/examples/replay_capture.py
@@ -1,11 +1,16 @@
-"""Decode a capture file instead of a live socket — the basis of a backtest.
+"""Decode saved frames instead of a live socket — the basis of a backtest.
 
-    rhfeed capture --seconds 600 session.jsonl
-    uv run python examples/replay_capture.py session.jsonl
+    uv run python examples/replay_capture.py                 # the bundled frames
+    uv run python examples/replay_capture.py session.jsonl   # your own
 
-Same decoder, no network. Whatever strategy you write against `FeedConsumer` should
-run unchanged here, which is how you test it against known traffic before pointing
-it at a live relay. This prints a profile of what the capture contained.
+Same decoder, no network, no relay. Whatever you write against `FeedConsumer` runs
+unchanged here, which is how you test it against known traffic first. This prints a
+profile of what the frames contained — the quickest way to find out which contracts
+and selectors are worth filtering on.
+
+Saving your own is four lines of `websockets`: connect to the relay and write each
+raw message to a file, one per line. That is exactly the format read here, and how
+`tests/frames.jsonl` was made.
 """
 
 from __future__ import annotations
@@ -13,8 +18,11 @@ from __future__ import annotations
 import json
 import sys
 from collections import Counter
+from pathlib import Path
 
 from rhfeed import parse_frame
+
+BUNDLED = Path(__file__).resolve().parent.parent / "tests" / "frames.jsonl"
 
 
 def main(path: str) -> None:
@@ -57,6 +65,6 @@ def main(path: str) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        sys.exit(f"usage: {sys.argv[0]} <capture.jsonl>")
-    main(sys.argv[1])
+    if len(sys.argv) > 2:
+        sys.exit(f"usage: {sys.argv[0]} [capture.jsonl]")
+    main(sys.argv[1] if len(sys.argv) == 2 else str(BUNDLED))

--- a/examples/token_flow.py
+++ b/examples/token_flow.py
@@ -16,9 +16,14 @@ Sender is read only for the handful that match, which is exactly the point of
 from __future__ import annotations
 
 import asyncio
+import time
 from collections import Counter
 
 from rhfeed import FeedConsumer, addr, selector_of
+
+#: Print a scan line this often even when nothing matched, so an idle run is visibly
+#: idle rather than indistinguishable from a broken one.
+HEARTBEAT_SECONDS = 15.0
 
 # Stock tokens are beacon proxies of one Stock implementation, so they share a
 # selector set. Swap in whichever contracts you care about.
@@ -41,9 +46,14 @@ TRANSFERS = {
 async def main() -> None:
     consumer = FeedConsumer()
     counts: Counter[str] = Counter()
+    scanned = 0
+    next_beat = time.monotonic() + HEARTBEAT_SECONDS
+
+    print(f"watching {', '.join(TOKENS.values())} for transfers — quiet is normal", flush=True)
 
     async for msg in consumer.live():
         for tx in msg.txs:
+            scanned += 1
             name = TOKENS.get(tx.to_bytes)
             if name is None or tx.selector not in TRANSFERS:
                 continue
@@ -51,8 +61,15 @@ async def main() -> None:
             # Only now is anything expensive computed.
             print(f"block {msg.seq}  {name:<6} {tx.hash}  from {tx.sender}", flush=True)
 
-        if msg.seq % 500 == 0 and counts:
-            print(f"# {dict(counts)}  ({consumer.stats['live_messages']} blocks)", flush=True)
+        # Unconditional, not gated on having matched something: a run with no matches
+        # is the expected case here, and it still needs to look alive.
+        if time.monotonic() >= next_beat:
+            next_beat = time.monotonic() + HEARTBEAT_SECONDS
+            print(
+                f"# {consumer.stats['live_messages']} blocks, {scanned} tx scanned, "
+                f"{sum(counts.values())} matched {dict(counts) or ''}".rstrip(),
+                flush=True,
+            )
 
 
 if __name__ == "__main__":

--- a/examples/token_flow.py
+++ b/examples/token_flow.py
@@ -31,8 +31,7 @@ HEARTBEAT_SECONDS = 15.0
 # Expect long silences on this default. The tokenised float is small — NVDA's whole
 # on-chain supply is a few thousand tokens — while the chain's actual traffic is ETH
 # and Uniswap. If you want to watch something busy while testing, point TOKENS at a
-# router instead: `rhfeed capture` a minute of frames and run
-# `examples/replay_capture.py` on it to see which contracts are actually moving.
+# router instead: `examples/replay_capture.py` prints which contracts are moving.
 TOKENS = {
     addr("0xd0601ce157db5bdc3162bbac2a2c8af5320d9eec"): "NVDA",
 }

--- a/src/rhfeed/cli.py
+++ b/src/rhfeed/cli.py
@@ -1,15 +1,17 @@
-"""Command line: watch a relay, or capture its frames for replay.
+"""Command line: stream decoded transactions from a Nitro relay.
 
-    rhfeed watch                          # decoded transactions from a local relay
-    rhfeed capture --seconds 300 out.jsonl
-    rhfeed watch --feed mainnet           # straight at the public feed, for a look
+    rhfeed                                    # everything the sequencer orders
+    rhfeed --to 0xcaf6...                     # one contract
+    rhfeed --selector 0x095ea7b3 --seconds 30 # ERC-20 approvals, for half a minute
+    rhfeed --json | jq                        # full addresses, machine-readable
 
-Both default to `ws://127.0.0.1:9642`, which is where `docker compose up -d relay`
-puts the official Nitro relay. Point `--feed` at a public endpoint only for a quick
-look — Robinhood rate-limits those per client, not per connection.
+Defaults to `ws://127.0.0.1:9642`, which is where `docker compose up -d relay` puts
+the official Nitro relay. `--feed mainnet` goes straight at Robinhood's public
+endpoint instead — fine for a look, but it rate-limits per client rather than per
+connection, which is the whole reason for running a relay.
 
-Progress and problems go to stderr, transactions to stdout, so `rhfeed watch --json
-| jq` keeps working while you can still see whether anything is connected.
+Progress and problems go to stderr, transactions to stdout, so a pipe keeps working
+while you can still see whether anything is connected.
 """
 
 from __future__ import annotations
@@ -20,7 +22,6 @@ import contextlib
 import json
 import logging
 import sys
-import time
 
 from .codec import Tx, addr, sel
 from .consume import DEFAULT_RELAY, MAINNET_FEED, TESTNET_FEED, FeedConsumer
@@ -28,7 +29,7 @@ from .consume import DEFAULT_RELAY, MAINNET_FEED, TESTNET_FEED, FeedConsumer
 FEEDS = {"mainnet": MAINNET_FEED, "testnet": TESTNET_FEED, "relay": DEFAULT_RELAY}
 
 #: How much of an address to print. Full hashes are worth their width because you
-#: paste them into an explorer; four addresses per line at 42 characters each are
+#: paste them into an explorer; several addresses per line at 42 characters each are
 #: not. The ellipsis is deliberate — see `--json` for values you can filter on.
 ADDR_WIDTH = 10
 
@@ -61,7 +62,6 @@ class Filter:
         self.to = {addr(a) for a in args.to} if args.to else None
         self.selector = {sel(s) for s in args.selector} if args.selector else None
         self.sender = {addr(a) for a in args.sender} if args.sender else None
-        self.min_value = args.min_value
 
     @property
     def wants_sender(self) -> bool:
@@ -69,19 +69,17 @@ class Filter:
 
     @property
     def active(self) -> bool:
-        return bool(self.to or self.selector or self.sender or self.min_value)
+        return bool(self.to or self.selector or self.sender)
 
     def keep(self, tx: Tx) -> bool:
         if self.to is not None and tx.to_bytes not in self.to:
             return False
         if self.selector is not None and tx.selector not in self.selector:
             return False
-        if self.min_value and tx.value < self.min_value:
-            return False
         return not (self.sender is not None and tx.sender_bytes not in self.sender)
 
 
-async def cmd_watch(args: argparse.Namespace) -> None:
+async def watch(args: argparse.Namespace) -> None:
     consumer = FeedConsumer(resolve_feed(args.feed))
     try:
         keep = Filter(args)
@@ -89,10 +87,9 @@ async def cmd_watch(args: argparse.Namespace) -> None:
         # A shortened address pasted out of the terminal lands here. Say so in one
         # line instead of unwinding a traceback through bytes.fromhex.
         sys.exit(f"rhfeed: {exc}")
-    # Printing a sender costs a recovery per transaction shown. That is fine for a
-    # handful of matches and wasteful for an unfiltered stream, so it is opt-in
-    # unless a sender filter already forced the work.
-    show_sender = args.sender_column or keep.wants_sender
+    # Recovering a sender is ~15x the cost of every other field put together, so it
+    # happens only when a --sender filter already forced the work.
+    show_sender = keep.wants_sender
     shown = 0
 
     # aclosing, not a bare `async for` + break: the generator is suspended inside the
@@ -148,96 +145,30 @@ async def cmd_watch(args: argparse.Namespace) -> None:
     )
 
 
-async def cmd_capture(args: argparse.Namespace) -> None:
-    """Save raw frames for replay — the basis of a backtest or a decoder test."""
-    import websockets
-
-    from .consume import FEED_CLIENT_VERSION
-
-    url = resolve_feed(args.feed)
-    written = 0
-    deadline = time.monotonic() + args.seconds
-    logging.getLogger(__name__).info("capturing from %s for %gs", url, args.seconds)
-    # Blocking file writes on the event loop, deliberately: this is a one-shot CLI
-    # writing ~15 lines a second, and a thread pool would only add moving parts.
-    with open(args.out, "w") as fh:  # noqa: ASYNC230
-        # One shot, no reconnect loop. If the relay is not there, say which relay and
-        # what to do about it, rather than unwinding a ConnectionRefusedError.
-        try:
-            async with websockets.connect(
-                url, additional_headers={FEED_CLIENT_VERSION: "2"}, max_size=2**24
-            ) as ws:
-                while time.monotonic() < deadline and written < args.frames:
-                    remaining = deadline - time.monotonic()
-                    try:
-                        raw = await asyncio.wait_for(ws.recv(), timeout=max(remaining, 0.1))
-                    except TimeoutError:
-                        break
-                    fh.write(raw if isinstance(raw, str) else raw.decode())
-                    fh.write("\n")
-                    written += 1
-        except OSError as exc:
-            sys.exit(
-                f"rhfeed: cannot reach {url} ({type(exc).__name__}: {exc})\n"
-                f"        is the relay running?  docker compose up -d relay"
-            )
-    if not written:
-        sys.exit(
-            f"rhfeed: {url} sent nothing in {args.seconds:g}s — check:  docker compose logs relay"
-        )
-    print(f"wrote {written} frames to {args.out}", file=sys.stderr)
-
-
-FEED_HELP = (
-    f"relay URL (default {DEFAULT_RELAY}), or 'mainnet' / 'testnet' for Robinhood's "
-    "public feed. Accepted before or after the subcommand"
-)
-QUIET_HELP = "only report problems on stderr, not connection and backlog progress"
-
-
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="rhfeed",
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    ap.add_argument("--feed", default=DEFAULT_RELAY, help=FEED_HELP)
-    ap.add_argument("--quiet", action="store_true", help=QUIET_HELP)
-
-    # The same options again on every subcommand, so that `rhfeed watch --feed
-    # mainnet` works as well as `rhfeed --feed mainnet watch`. SUPPRESS is what makes
-    # that safe: without it the subparser's default would overwrite whatever was
-    # given before the subcommand.
-    common = argparse.ArgumentParser(add_help=False)
-    common.add_argument("--feed", default=argparse.SUPPRESS, help=FEED_HELP)
-    common.add_argument("--quiet", action="store_true", default=argparse.SUPPRESS, help=QUIET_HELP)
-
-    sub = ap.add_subparsers(dest="command", required=True)
-
-    watch = sub.add_parser("watch", help="stream decoded transactions", parents=[common])
-    watch.add_argument(
+    ap.add_argument(
+        "--feed",
+        default=DEFAULT_RELAY,
+        help=f"relay URL (default {DEFAULT_RELAY}), or 'mainnet' / 'testnet' for "
+        "Robinhood's public feed",
+    )
+    ap.add_argument(
         "--seconds", type=float, help="stop after this long, whether or not anything arrives"
     )
-    watch.add_argument("--json", action="store_true", help="one JSON object per message")
-    watch.add_argument("--to", action="append", help="only transactions to this address")
-    watch.add_argument("--selector", action="append", help="only calls with this 4-byte selector")
-    watch.add_argument(
-        "--sender", action="append", help="only transactions from this address (forces recovery)"
+    ap.add_argument("--json", action="store_true", help="one JSON object per message")
+    ap.add_argument("--to", action="append", help="only transactions to this address")
+    ap.add_argument("--selector", action="append", help="only calls with this 4-byte selector")
+    ap.add_argument(
+        "--sender",
+        action="append",
+        help="only transactions from this address, and show who sent each one. "
+        "Forces a signature recovery per transaction",
     )
-    watch.add_argument("--min-value", type=int, default=0, help="only transfers of at least N wei")
-    watch.add_argument(
-        "--sender-column", action="store_true", help="resolve and print senders (costs a recovery)"
-    )
-    watch.set_defaults(func=cmd_watch)
-
-    cap = sub.add_parser(
-        "capture", help="append raw frames to a .jsonl file for replay", parents=[common]
-    )
-    cap.add_argument("out")
-    cap.add_argument("--seconds", type=float, default=60.0)
-    cap.add_argument("--frames", type=int, default=100_000)
-    cap.set_defaults(func=cmd_capture)
-
     return ap
 
 
@@ -246,13 +177,9 @@ def main() -> None:
     # Connection notes and warnings are the difference between "nothing is happening"
     # and "nothing is happening *because*". They go to stderr, prefixed like the
     # summary line, so redirecting stdout still leaves them visible.
-    logging.basicConfig(
-        level=logging.WARNING if args.quiet else logging.INFO,
-        format="# %(message)s",
-        stream=sys.stderr,
-    )
+    logging.basicConfig(level=logging.INFO, format="# %(message)s", stream=sys.stderr)
     with contextlib.suppress(KeyboardInterrupt):
-        asyncio.run(args.func(args))
+        asyncio.run(watch(args))
 
 
 if __name__ == "__main__":

--- a/src/rhfeed/cli.py
+++ b/src/rhfeed/cli.py
@@ -210,9 +210,7 @@ def build_parser() -> argparse.ArgumentParser:
     # given before the subcommand.
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--feed", default=argparse.SUPPRESS, help=FEED_HELP)
-    common.add_argument(
-        "--quiet", action="store_true", default=argparse.SUPPRESS, help=QUIET_HELP
-    )
+    common.add_argument("--quiet", action="store_true", default=argparse.SUPPRESS, help=QUIET_HELP)
 
     sub = ap.add_subparsers(dest="command", required=True)
 

--- a/src/rhfeed/cli.py
+++ b/src/rhfeed/cli.py
@@ -4,7 +4,7 @@
     rhfeed capture --seconds 300 out.jsonl
     rhfeed watch --feed mainnet           # straight at the public feed, for a look
 
-Both default to `ws://127.0.0.1:9642`, which is where `docker compose up relay`
+Both default to `ws://127.0.0.1:9642`, which is where `docker compose up -d relay`
 puts the official Nitro relay. Point `--feed` at a public endpoint only for a quick
 look — Robinhood rate-limits those per client, not per connection.
 
@@ -192,6 +192,7 @@ FEED_HELP = (
     f"relay URL (default {DEFAULT_RELAY}), or 'mainnet' / 'testnet' for Robinhood's "
     "public feed. Accepted before or after the subcommand"
 )
+QUIET_HELP = "only report problems on stderr, not connection and backlog progress"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -201,11 +202,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     ap.add_argument("--feed", default=DEFAULT_RELAY, help=FEED_HELP)
-    ap.add_argument(
-        "--quiet",
-        action="store_true",
-        help="suppress the connection and backlog notes on stderr",
-    )
+    ap.add_argument("--quiet", action="store_true", help=QUIET_HELP)
 
     # The same options again on every subcommand, so that `rhfeed watch --feed
     # mainnet` works as well as `rhfeed --feed mainnet watch`. SUPPRESS is what makes
@@ -213,7 +210,9 @@ def build_parser() -> argparse.ArgumentParser:
     # given before the subcommand.
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--feed", default=argparse.SUPPRESS, help=FEED_HELP)
-    common.add_argument("--quiet", action="store_true", default=argparse.SUPPRESS)
+    common.add_argument(
+        "--quiet", action="store_true", default=argparse.SUPPRESS, help=QUIET_HELP
+    )
 
     sub = ap.add_subparsers(dest="command", required=True)
 

--- a/src/rhfeed/cli.py
+++ b/src/rhfeed/cli.py
@@ -2,10 +2,14 @@
 
     rhfeed watch                          # decoded transactions from a local relay
     rhfeed capture --seconds 300 out.jsonl
+    rhfeed watch --feed mainnet           # straight at the public feed, for a look
 
 Both default to `ws://127.0.0.1:9642`, which is where `docker compose up relay`
 puts the official Nitro relay. Point `--feed` at a public endpoint only for a quick
 look — Robinhood rate-limits those per client, not per connection.
+
+Progress and problems go to stderr, transactions to stdout, so `rhfeed watch --json
+| jq` keeps working while you can still see whether anything is connected.
 """
 
 from __future__ import annotations
@@ -14,6 +18,7 @@ import argparse
 import asyncio
 import contextlib
 import json
+import logging
 import sys
 import time
 
@@ -22,9 +27,26 @@ from .consume import DEFAULT_RELAY, MAINNET_FEED, TESTNET_FEED, FeedConsumer
 
 FEEDS = {"mainnet": MAINNET_FEED, "testnet": TESTNET_FEED, "relay": DEFAULT_RELAY}
 
+#: How much of an address to print. Full hashes are worth their width because you
+#: paste them into an explorer; four addresses per line at 42 characters each are
+#: not. The ellipsis is deliberate — see `--json` for values you can filter on.
+ADDR_WIDTH = 10
+
 
 def resolve_feed(value: str) -> str:
     return FEEDS.get(value, value)
+
+
+def short(address: str | None, placeholder: str = "deploy") -> str:
+    if address is None:
+        return placeholder.ljust(ADDR_WIDTH + 3)
+    return f"{address[: ADDR_WIDTH + 2]}…"
+
+
+@contextlib.asynccontextmanager
+async def _forever():
+    """Stand-in for `asyncio.timeout` when --seconds was not given."""
+    yield
 
 
 class Filter:
@@ -61,58 +83,67 @@ class Filter:
 
 async def cmd_watch(args: argparse.Namespace) -> None:
     consumer = FeedConsumer(resolve_feed(args.feed))
-    keep = Filter(args)
+    try:
+        keep = Filter(args)
+    except ValueError as exc:
+        # A shortened address pasted out of the terminal lands here. Say so in one
+        # line instead of unwinding a traceback through bytes.fromhex.
+        sys.exit(f"rhfeed: {exc}")
     # Printing a sender costs a recovery per transaction shown. That is fine for a
     # handful of matches and wasteful for an unfiltered stream, so it is opt-in
     # unless a sender filter already forced the work.
     show_sender = args.sender_column or keep.wants_sender
-    deadline = time.monotonic() + args.seconds if args.seconds else None
-    matched = 0
+    shown = 0
 
     # aclosing, not a bare `async for` + break: the generator is suspended inside the
     # websocket context manager, and letting the GC close it later unwinds that from
-    # the wrong task.
+    # the wrong task. The timeout goes inside it so it unwinds first, leaving a live
+    # generator for aclosing to shut down.
     async with contextlib.aclosing(consumer.live()) as stream:
-        async for msg in stream:
-            if deadline and time.monotonic() > deadline:
-                break
+        # asyncio.timeout, not a deadline checked per message: the whole point of
+        # --seconds is to bound a run that might see no messages at all.
+        with contextlib.suppress(TimeoutError):
+            async with asyncio.timeout(args.seconds) if args.seconds else _forever():
+                async for msg in stream:
+                    txs = [t for t in msg.txs if keep.keep(t)] if keep.active else msg.txs
+                    if not txs and keep.active:
+                        continue
+                    shown += len(txs)
 
-            txs = [t for t in msg.txs if keep.keep(t)] if keep.active else msg.txs
-            if not txs and keep.active:
-                continue
-            matched += len(txs)
-
-            if args.json:
-                print(
-                    json.dumps(
-                        {
-                            "seq": msg.seq,
-                            "timestamp": msg.timestamp,
-                            "received_at": round(msg.received_at, 6),
-                            "kind": msg.l1_kind_name,
-                            "from_parent_chain": msg.from_parent_chain,
-                            "txs": [t.as_dict(sender=show_sender) for t in txs],
-                        }
-                    ),
-                    flush=True,
-                )
-            else:
-                tag = "" if not msg.from_parent_chain else f" [{msg.l1_kind_name}]"
-                print(f"seq {msg.seq}{tag}  {len(txs)} tx", flush=True)
-                for t in txs:
-                    # Full hash: a truncated one is only good for eyeballing, and you
-                    # generally want to paste this into an explorer or a node call.
-                    who = f"{(t.sender or '?')[:12]} -> " if show_sender else ""
-                    print(
-                        f"    {t.hash}  {t.kind:<8} {who}"
-                        f"{(t.to or 'deploy')[:12]}  {t.selector_hex or ''}",
-                        flush=True,
-                    )
+                    if args.json:
+                        print(
+                            json.dumps(
+                                {
+                                    "seq": msg.seq,
+                                    "timestamp": msg.timestamp,
+                                    "received_at": round(msg.received_at, 6),
+                                    "kind": msg.l1_kind_name,
+                                    "from_parent_chain": msg.from_parent_chain,
+                                    "txs": [t.as_dict(sender=show_sender) for t in txs],
+                                }
+                            ),
+                            flush=True,
+                        )
+                    else:
+                        tag = "" if not msg.from_parent_chain else f" [{msg.l1_kind_name}]"
+                        print(f"seq {msg.seq}{tag}  {len(txs)} tx", flush=True)
+                        for t in txs:
+                            # Full hash: a truncated one is only good for eyeballing,
+                            # and you generally want to paste this into an explorer or
+                            # a node call. Addresses are elided — use --json for ones
+                            # you can feed back into --to / --sender.
+                            who = f"{short(t.sender, '?')} -> " if show_sender else ""
+                            print(
+                                f"    {t.hash}  {t.kind:<8} {who}"
+                                f"{short(t.to)}  {t.selector_hex or ''}",
+                                flush=True,
+                            )
 
     s = consumer.stats
+    counted = "matched" if keep.active else "seen"
     print(
-        f"# {matched} transactions matched | {s['live_messages']} live messages, "
-        f"{s['backlog_messages']} backlog skipped, {s['reconnects']} reconnects",
+        f"# {shown} transactions {counted} | {s['live_messages']} live messages, "
+        f"{s['backlog_messages']} backlog skipped, {s['reconnects']} failed connections",
         file=sys.stderr,
     )
 
@@ -126,35 +157,70 @@ async def cmd_capture(args: argparse.Namespace) -> None:
     url = resolve_feed(args.feed)
     written = 0
     deadline = time.monotonic() + args.seconds
+    logging.getLogger(__name__).info("capturing from %s for %gs", url, args.seconds)
     # Blocking file writes on the event loop, deliberately: this is a one-shot CLI
     # writing ~15 lines a second, and a thread pool would only add moving parts.
     with open(args.out, "w") as fh:  # noqa: ASYNC230
-        async with websockets.connect(
-            url, additional_headers={FEED_CLIENT_VERSION: "2"}, max_size=2**24
-        ) as ws:
-            while time.monotonic() < deadline and written < args.frames:
-                remaining = deadline - time.monotonic()
-                try:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=max(remaining, 0.1))
-                except TimeoutError:
-                    break
-                fh.write(raw if isinstance(raw, str) else raw.decode())
-                fh.write("\n")
-                written += 1
+        # One shot, no reconnect loop. If the relay is not there, say which relay and
+        # what to do about it, rather than unwinding a ConnectionRefusedError.
+        try:
+            async with websockets.connect(
+                url, additional_headers={FEED_CLIENT_VERSION: "2"}, max_size=2**24
+            ) as ws:
+                while time.monotonic() < deadline and written < args.frames:
+                    remaining = deadline - time.monotonic()
+                    try:
+                        raw = await asyncio.wait_for(ws.recv(), timeout=max(remaining, 0.1))
+                    except TimeoutError:
+                        break
+                    fh.write(raw if isinstance(raw, str) else raw.decode())
+                    fh.write("\n")
+                    written += 1
+        except OSError as exc:
+            sys.exit(
+                f"rhfeed: cannot reach {url} ({type(exc).__name__}: {exc})\n"
+                f"        is the relay running?  docker compose up -d relay"
+            )
+    if not written:
+        sys.exit(
+            f"rhfeed: {url} sent nothing in {args.seconds:g}s — check:  docker compose logs relay"
+        )
     print(f"wrote {written} frames to {args.out}", file=sys.stderr)
 
 
+FEED_HELP = (
+    f"relay URL (default {DEFAULT_RELAY}), or 'mainnet' / 'testnet' for Robinhood's "
+    "public feed. Accepted before or after the subcommand"
+)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    ap = argparse.ArgumentParser(prog="rhfeed", description=__doc__)
-    ap.add_argument(
-        "--feed",
-        default=DEFAULT_RELAY,
-        help="relay URL (default), or 'mainnet' / 'testnet' for the public feed",
+    ap = argparse.ArgumentParser(
+        prog="rhfeed",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    ap.add_argument("--feed", default=DEFAULT_RELAY, help=FEED_HELP)
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress the connection and backlog notes on stderr",
+    )
+
+    # The same options again on every subcommand, so that `rhfeed watch --feed
+    # mainnet` works as well as `rhfeed --feed mainnet watch`. SUPPRESS is what makes
+    # that safe: without it the subparser's default would overwrite whatever was
+    # given before the subcommand.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--feed", default=argparse.SUPPRESS, help=FEED_HELP)
+    common.add_argument("--quiet", action="store_true", default=argparse.SUPPRESS)
+
     sub = ap.add_subparsers(dest="command", required=True)
 
-    watch = sub.add_parser("watch", help="stream decoded transactions")
-    watch.add_argument("--seconds", type=float, help="stop after this long")
+    watch = sub.add_parser("watch", help="stream decoded transactions", parents=[common])
+    watch.add_argument(
+        "--seconds", type=float, help="stop after this long, whether or not anything arrives"
+    )
     watch.add_argument("--json", action="store_true", help="one JSON object per message")
     watch.add_argument("--to", action="append", help="only transactions to this address")
     watch.add_argument("--selector", action="append", help="only calls with this 4-byte selector")
@@ -167,7 +233,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     watch.set_defaults(func=cmd_watch)
 
-    cap = sub.add_parser("capture", help="append raw frames to a .jsonl file for replay")
+    cap = sub.add_parser(
+        "capture", help="append raw frames to a .jsonl file for replay", parents=[common]
+    )
     cap.add_argument("out")
     cap.add_argument("--seconds", type=float, default=60.0)
     cap.add_argument("--frames", type=int, default=100_000)
@@ -178,6 +246,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_parser().parse_args()
+    # Connection notes and warnings are the difference between "nothing is happening"
+    # and "nothing is happening *because*". They go to stderr, prefixed like the
+    # summary line, so redirecting stdout still leaves them visible.
+    logging.basicConfig(
+        level=logging.WARNING if args.quiet else logging.INFO,
+        format="# %(message)s",
+        stream=sys.stderr,
+    )
     with contextlib.suppress(KeyboardInterrupt):
         asyncio.run(args.func(args))
 

--- a/src/rhfeed/codec.py
+++ b/src/rhfeed/codec.py
@@ -72,16 +72,29 @@ def selector_of(signature: str) -> bytes:
     return keccak(signature.encode())[:4]
 
 
+def _unhex(value: str, what: str) -> bytes:
+    # bytes.fromhex raises before any length check, and its message ("non-hexadecimal
+    # number found in fromhex() arg at position 8") says nothing useful to someone who
+    # pasted a shortened address off the terminal. Say what was wrong with what.
+    try:
+        return bytes.fromhex(value.removeprefix("0x"))
+    except ValueError as exc:
+        raise ValueError(f"not a hex {what}: {value!r}") from exc
+
+
 def sel(hex_selector: str) -> bytes:
     """4-byte selector from its hex form, with or without the 0x."""
-    return bytes.fromhex(hex_selector.removeprefix("0x"))
+    raw = _unhex(hex_selector, "selector")
+    if len(raw) != 4:
+        raise ValueError(f"not a 4-byte selector: {hex_selector!r} is {len(raw)} bytes")
+    return raw
 
 
 def addr(hex_address: str) -> bytes:
     """20 raw bytes from a hex address, for membership tests against `to_bytes`."""
-    raw = bytes.fromhex(hex_address.removeprefix("0x"))
+    raw = _unhex(hex_address, "address")
     if len(raw) != 20:
-        raise ValueError(f"not a 20-byte address: {hex_address}")
+        raise ValueError(f"not a 20-byte address: {hex_address!r} is {len(raw)} bytes")
     return raw
 
 

--- a/src/rhfeed/consume.py
+++ b/src/rhfeed/consume.py
@@ -26,17 +26,27 @@ seen number is always in range, and costs exactly one duplicate, which is droppe
 
 **Sender recovery on the hot path.** Never done here. `tx.sender` is lazy — ask for
 it on the handful of transactions that survive your filter, not on all of them.
+
+**Silence.** A relay that is not running, a relay whose own upstream connection is
+down, a relay still replaying its backlog, and a chain that happens to be quiet all
+look identical from here: no messages. So this module says which one it is, through
+`logging` — warnings for a connection that will not open and for one that has gone
+quiet, info for connecting, draining and going live. Warnings reach stderr with no
+setup; `logging.getLogger("rhfeed").setLevel(...)` mutes or unmutes the rest.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import AsyncIterator
 
 import websockets
 
 from .codec import FeedMessage, parse_frame
+
+_log = logging.getLogger(__name__)
 
 try:  # 2-3x faster than the stdlib on frames this size; optional
     from orjson import loads as _loads
@@ -66,12 +76,17 @@ class FeedConsumer:
         max_backlog_seconds: float = 120.0,
         reconnect_delay: float = 0.5,
         max_reconnect_delay: float = 30.0,
+        stall_warning: float = 30.0,
     ) -> None:
         self.url = url
         self.live_threshold = live_threshold
         self.max_backlog_seconds = max_backlog_seconds
         self.reconnect_delay = reconnect_delay
         self.max_reconnect_delay = max_reconnect_delay
+        #: Warn after this long with an open connection and no frames. The chain
+        #: produces several blocks a second, so silence this long is a fault
+        #: somewhere, usually the relay's own upstream. 0 disables the check.
+        self.stall_warning = stall_warning
 
         self.stats = {
             "frames": 0,
@@ -82,6 +97,7 @@ class FeedConsumer:
         }
         self._live = False
         self._highest_seq = -1
+        self._last_frame_at = 0.0
 
     @property
     def is_live(self) -> bool:
@@ -110,7 +126,54 @@ class FeedConsumer:
             # Fallback for a skewed clock: the backlog is finite, so stop waiting.
             or (now - started) > self.max_backlog_seconds
         )
+        if self._live:
+            _log.info(
+                "live — %d backlog messages skipped, at seq %d",
+                self.stats["backlog_messages"],
+                self._highest_seq,
+            )
         return self._live
+
+    async def _monitor(self) -> None:
+        """Narrate an open connection that has not started producing yet.
+
+        Two silences look identical from outside and mean different things. A relay
+        whose own upstream is down holds the socket open and never sends anything —
+        that is a fault, and it warns. A relay still replaying its backlog is sending
+        plenty, none of it live yet — that is normal, and it just reports progress.
+        """
+        # Poll well inside the threshold, or a stall that starts just after a tick
+        # goes unreported for twice as long as advertised.
+        interval = max(self.stall_warning / 4, 0.1)
+        warned = False
+        while True:
+            await asyncio.sleep(interval)
+            if not self._last_frame_at:
+                # No connection to be stalled on; the reconnect loop is already saying so.
+                warned = False
+                continue
+
+            idle = time.monotonic() - self._last_frame_at
+            if idle >= self.stall_warning:
+                if not warned:
+                    warned = True  # once per stall, not once per poll
+                    _log.warning(
+                        "no frames from %s for %.0fs — connected, but nothing is arriving. "
+                        "Usually the relay's own upstream is down "
+                        "(check: docker compose logs relay)",
+                        self.url,
+                        idle,
+                    )
+                continue
+
+            warned = False
+            if not self._live:
+                # Frames are flowing but none are current yet. Common on a relay that
+                # has just started, because it is replaying its own upstream backlog.
+                _log.info(
+                    "draining backlog — %d messages so far, none current yet",
+                    self.stats["backlog_messages"],
+                )
 
     async def messages(self, decode_backlog: bool = True) -> AsyncIterator[FeedMessage]:
         """Yield every message, backlog first, reconnecting until cancelled.
@@ -120,26 +183,55 @@ class FeedConsumer:
         its sequence number, but no transaction is decoded.
         """
         delay = self.reconnect_delay
-        while True:
-            try:
-                async with websockets.connect(
-                    self.url, additional_headers=self._headers(), max_size=2**24
-                ) as ws:
-                    delay = self.reconnect_delay
-                    started = time.time()
-                    self._live = False
-                    async for raw in ws:
-                        self.stats["frames"] += 1
-                        received = time.time()
-                        for msg in self._frame(_loads(raw), started, decode_backlog):
-                            msg.received_at = received
-                            yield msg
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                self.stats["reconnects"] += 1
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, self.max_reconnect_delay)
+        failures = 0
+        monitor = asyncio.create_task(self._monitor()) if self.stall_warning else None
+        try:
+            while True:
+                try:
+                    _log.info("connecting to %s", self.url)
+                    async with websockets.connect(
+                        self.url, additional_headers=self._headers(), max_size=2**24
+                    ) as ws:
+                        if failures:
+                            _log.warning("%s is reachable again", self.url)
+                        failures = 0
+                        delay = self.reconnect_delay
+                        started = time.time()
+                        self._live = False
+                        self._last_frame_at = time.monotonic()
+                        async for raw in ws:
+                            self.stats["frames"] += 1
+                            received = time.time()
+                            self._last_frame_at = time.monotonic()
+                            for msg in self._frame(_loads(raw), started, decode_backlog):
+                                msg.received_at = received
+                                yield msg
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    failures += 1
+                    self.stats["reconnects"] += 1
+                    # Never fail silently here. A relay that was never started is the
+                    # single most common way to end up staring at an empty terminal,
+                    # and the retry loop would otherwise hide it forever.
+                    _log.warning(
+                        "cannot read %s (%s: %s) — retrying in %.1fs%s",
+                        self.url,
+                        type(exc).__name__,
+                        exc,
+                        delay,
+                        "; is the relay running? (docker compose up -d relay)"
+                        if failures == 1
+                        else "",
+                    )
+                    self._last_frame_at = 0.0
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self.max_reconnect_delay)
+        finally:
+            if monitor is not None:
+                # Cancel without awaiting: this runs during aclose(), which may itself
+                # be unwinding a cancellation.
+                monitor.cancel()
 
     def _frame(self, frame: dict, started: float, decode_backlog: bool):
         # Decide liveness from the frame's own timestamps before deciding whether the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,35 +15,24 @@ import time
 import pytest
 
 from rhfeed import FeedConsumer, addr, sel
-from rhfeed.cli import ADDR_WIDTH, Filter, build_parser, short
+from rhfeed.cli import ADDR_WIDTH, Filter, build_parser, resolve_feed, short
 
 # --------------------------------------------------------------------------- #
-# argument placement
+# arguments
 # --------------------------------------------------------------------------- #
-
-
-@pytest.mark.parametrize(
-    "argv",
-    [
-        ["--feed", "mainnet", "watch"],
-        ["watch", "--feed", "mainnet"],
-        ["--feed", "mainnet", "capture", "out.jsonl"],
-        ["capture", "out.jsonl", "--feed", "mainnet"],
-    ],
-)
-def test_feed_is_accepted_on_either_side_of_the_subcommand(argv):
-    assert build_parser().parse_args(argv).feed == "mainnet"
 
 
 def test_feed_defaults_to_the_local_relay():
-    assert build_parser().parse_args(["watch"]).feed == "ws://127.0.0.1:9642"
+    assert build_parser().parse_args([]).feed == "ws://127.0.0.1:9642"
 
 
-def test_a_subcommand_default_does_not_overwrite_an_earlier_feed():
-    """The reason --feed uses SUPPRESS on the subparsers."""
-    args = build_parser().parse_args(["--feed", "testnet", "watch", "--json"])
-    assert args.feed == "testnet"
-    assert args.json is True
+@pytest.mark.parametrize("name", ["mainnet", "testnet"])
+def test_named_feeds_resolve_to_robinhoods_endpoints(name):
+    assert resolve_feed(name).startswith("wss://feed.")
+
+
+def test_an_unrecognised_feed_is_passed_through_as_a_url():
+    assert resolve_feed("ws://10.0.0.5:9642") == "ws://10.0.0.5:9642"
 
 
 # --------------------------------------------------------------------------- #
@@ -76,7 +65,7 @@ def test_sel_says_what_was_wrong(value, message):
 
 
 def test_filter_rejects_a_bad_address_with_a_value_error():
-    args = build_parser().parse_args(["watch", "--to", "0xcaf681a6..."])
+    args = build_parser().parse_args(["--to", "0xcaf681a6..."])
     with pytest.raises(ValueError, match="not a hex address"):
         Filter(args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,177 @@
+"""The command line and the consumer's failure reporting.
+
+`test_codec.py` checks that the decoder is right. This file checks the things a
+newcomer hits before the decoder ever runs: argument placement, what a mistyped
+address says, and whether a relay that is not there stays silent about it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+
+import pytest
+
+from rhfeed import FeedConsumer, addr, sel
+from rhfeed.cli import ADDR_WIDTH, Filter, build_parser, short
+
+# --------------------------------------------------------------------------- #
+# argument placement
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--feed", "mainnet", "watch"],
+        ["watch", "--feed", "mainnet"],
+        ["--feed", "mainnet", "capture", "out.jsonl"],
+        ["capture", "out.jsonl", "--feed", "mainnet"],
+    ],
+)
+def test_feed_is_accepted_on_either_side_of_the_subcommand(argv):
+    assert build_parser().parse_args(argv).feed == "mainnet"
+
+
+def test_feed_defaults_to_the_local_relay():
+    assert build_parser().parse_args(["watch"]).feed == "ws://127.0.0.1:9642"
+
+
+def test_a_subcommand_default_does_not_overwrite_an_earlier_feed():
+    """The reason --feed uses SUPPRESS on the subparsers."""
+    args = build_parser().parse_args(["--feed", "testnet", "watch", "--json"])
+    assert args.feed == "testnet"
+    assert args.json is True
+
+
+# --------------------------------------------------------------------------- #
+# what a mistake says
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        # The shape you get by copying an address out of the terminal output.
+        ("0xcaf681a6...", "not a hex address"),
+        ("nonsense", "not a hex address"),
+        ("0xcaf681a66d", "not a 20-byte address"),
+        ("", "not a 20-byte address"),
+    ],
+)
+def test_addr_says_what_was_wrong(value, message):
+    with pytest.raises(ValueError, match=message):
+        addr(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [("0xzz", "not a hex selector"), ("0xdead", "not a 4-byte selector")],
+)
+def test_sel_says_what_was_wrong(value, message):
+    with pytest.raises(ValueError, match=message):
+        sel(value)
+
+
+def test_filter_rejects_a_bad_address_with_a_value_error():
+    args = build_parser().parse_args(["watch", "--to", "0xcaf681a6..."])
+    with pytest.raises(ValueError, match="not a hex address"):
+        Filter(args)
+
+
+# --------------------------------------------------------------------------- #
+# output
+# --------------------------------------------------------------------------- #
+
+
+def test_short_marks_that_it_elided():
+    """Elided, not silently truncated — a shortened address is not a valid filter."""
+    out = short("0xCaf681a66D020601342297493863E78C959e5cB2")
+    assert out.startswith("0xCaf681a66D")
+    assert out.endswith("…")
+    assert len(out) == ADDR_WIDTH + 3
+
+
+def test_short_pads_a_deploy_to_the_same_width():
+    assert len(short(None)) == len(short("0x" + "ab" * 20))
+
+
+# --------------------------------------------------------------------------- #
+# not failing silently
+# --------------------------------------------------------------------------- #
+
+
+async def _drain(consumer: FeedConsumer, seconds: float) -> None:
+    async with contextlib.aclosing(consumer.live()) as stream:
+        with contextlib.suppress(TimeoutError):
+            async with asyncio.timeout(seconds):
+                async for _ in stream:
+                    pass
+
+
+def test_an_unreachable_relay_is_reported_not_swallowed(caplog):
+    """The retry loop must not turn a missing relay into an empty terminal."""
+    consumer = FeedConsumer("ws://127.0.0.1:1", reconnect_delay=0.05)
+    with caplog.at_level(logging.WARNING, logger="rhfeed.consume"):
+        asyncio.run(_drain(consumer, 0.6))
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a relay that cannot be reached produced no warning"
+    assert "cannot read ws://127.0.0.1:1" in warnings[0]
+    assert "is the relay running" in warnings[0]
+    assert consumer.stats["reconnects"] > 0
+
+
+def test_seconds_stops_a_run_that_never_receives_anything():
+    """--seconds bounds the run itself, not the gap between messages.
+
+    Without the timeout wrapping the whole stream this hangs forever, because the
+    deadline used to be checked only on arrival of a message that never comes.
+    """
+    consumer = FeedConsumer("ws://127.0.0.1:1", reconnect_delay=0.05)
+    asyncio.run(asyncio.wait_for(_drain(consumer, 0.3), timeout=5))
+
+
+def test_stall_warning_fires_once_per_episode(caplog):
+    """A connection that goes quiet warns, and does not then warn every poll."""
+    consumer = FeedConsumer("ws://127.0.0.1:1", stall_warning=0.2)
+
+    async def run() -> None:
+        # Pretend a connection is open and delivered its last frame a while ago.
+        watchdog = asyncio.create_task(consumer._monitor())
+        consumer._last_frame_at = time.monotonic() - 10
+        await asyncio.sleep(0.5)
+        watchdog.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watchdog
+
+    with caplog.at_level(logging.WARNING, logger="rhfeed.consume"):
+        asyncio.run(run())
+
+    stalls = [r for r in caplog.records if "nothing is arriving" in r.getMessage()]
+    assert len(stalls) == 1, f"expected one stall warning, got {len(stalls)}"
+
+
+def test_a_draining_backlog_reports_progress_instead_of_warning(caplog):
+    """Frames arriving but none current yet is normal on a relay that just started."""
+    consumer = FeedConsumer("ws://127.0.0.1:1", stall_warning=0.4)
+    consumer.stats["backlog_messages"] = 500
+
+    async def run() -> None:
+        monitor = asyncio.create_task(consumer._monitor())
+        # Frames are flowing — just none of them live.
+        for _ in range(5):
+            consumer._last_frame_at = time.monotonic()
+            await asyncio.sleep(0.1)
+        monitor.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await monitor
+
+    with caplog.at_level(logging.INFO, logger="rhfeed.consume"):
+        asyncio.run(run())
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("draining backlog" in m for m in messages), messages
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)


### PR DESCRIPTION
Ran the repo cold as a newcomer, fixed what tripped me up, then removed
what the repo does not need to make its point.

## Why

Every way a first run can fail looked identical: an empty terminal. A relay
that was never started, a relay whose own upstream is down, a relay still
replaying its backlog and a quiet chain all produced no output and no
explanation, because the reconnect loop swallowed every exception.

## What changed

**Nothing fails silently any more.** `consume.py` reports connection failures,
recovery, backlog progress and going live through `logging`. A watchdog covers
the connected-but-silent case, which nothing the relay exposes can tell you
about. `docker compose up -d --wait relay` now blocks until the relay serves.

**One command, not two.** `rhfeed capture` is gone, and with it every
subcommand — no subparser, no shared parent parser, no `argparse.SUPPRESS`
trick. `--min-value` and `--quiet` went too, and `--sender-column` folded into
`--sender`. `cli.py` 216 → 154 lines.

**`--seconds` works.** It was checked only on arrival of a message, so it never
fired on the runs that most needed it. Now `asyncio.timeout` bounds the stream.

**Errors say what is wrong.** `rhfeed: not a hex address: '0xcaf681a6...'`
instead of a traceback through `bytes.fromhex`. Printed addresses end in `…` so
it is visible that they are not valid filter input; `--json` has the full ones.

**The speed claims are checkable.** `examples/bench.py` reproduces the README
table on your hardware, `--reference` times the libraries the fast paths
replace. `replay_capture.py` runs offline against the bundled frames, ranks
contracts, selectors and wallets, and times the recoveries.

**README:** `uv` as a prerequisite, a troubleshooting section, how to install
into your own project, copy-pasteable addresses, and how to stop the relay.

## Verification

71 tests passing, up from 54 — `tests/test_cli.py` is new and covers argument
handling, error text and each silence case. `ruff check` and
`ruff format --check` clean. Every fix was verified against the live chain,
including pausing the relay container mid-stream to trigger the stall warning.

One measurement bug caught along the way: a naive per-transaction recovery
timing over the 143-transaction fixture reported 213 µs against a true 48 µs,
because coincurve builds its context on the first call (~16 ms). That first
call is now excluded, and the figure reconciles with `bench.py`.

## Not addressed

Raised separately and left alone: no CI, three names for one thing
(`robinhood-chain-sequencer-feed` / `rhfeed-kit` / `rhfeed`), not on PyPI, no
`CONTRIBUTING`, and `ruff` is not a declared dev dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)