### PR TITLE
fix: keep the envelope fields that make a reorg detectable

### DIFF
--- a/src/rhfeed/codec.py
+++ b/src/rhfeed/codec.py
@@ -428,21 +428,64 @@ def decode_l2_message(payload: bytes) -> list[Tx]:
 
 
 class FeedMessage:
-    """One sequencer message. On this chain, `seq` equals the L2 block number."""
+    """One sequencer message. On this chain, `seq` equals the L2 block number.
 
-    __slots__ = ("l1_kind", "l1_sender", "live", "received_at", "seq", "timestamp", "txs")
+    `block_hash` is the block the sequencer had already built when it broadcast this —
+    it orders, executes, *then* announces. Two uses: ask a node for exactly this block
+    (`eth_getBlockReceipts` takes a hash, so you need no polling by number), and tell a
+    reorg from a duplicate, which is the only way the protocol offers. See
+    `FeedConsumer`.
+
+    `delayed_messages_read` is the running count of delayed-inbox messages the chain has
+    consumed. A jump between consecutive messages means the sequencer just pulled that
+    many out of the delayed inbox — L1 deposits, retryables, or a force inclusion
+    routing around the sequencer entirely.
+
+    `l1_block_number` is the parent-chain (Ethereum) block the sequencer had seen.
+    """
+
+    __slots__ = (
+        "block_hash",
+        "delayed_messages_read",
+        "l1_block_number",
+        "l1_kind",
+        "l1_sender",
+        "live",
+        "received_at",
+        "received_monotonic",
+        "reorg",
+        "seq",
+        "timestamp",
+        "txs",
+    )
 
     def __init__(
-        self, seq: int, l1_kind: int, l1_sender: str | None, timestamp: int, txs: list[Tx]
+        self,
+        seq: int,
+        l1_kind: int,
+        l1_sender: str | None,
+        timestamp: int,
+        txs: list[Tx],
+        block_hash: str | None = None,
+        delayed_messages_read: int = 0,
+        l1_block_number: int = 0,
     ) -> None:
         self.seq = seq
         self.l1_kind = l1_kind
         self.l1_sender = l1_sender
         self.timestamp = timestamp
         self.txs = txs
+        self.block_hash = block_hash
+        self.delayed_messages_read = delayed_messages_read
+        self.l1_block_number = l1_block_number
         # Set by FeedConsumer; meaningless for a frame decoded straight off disk.
         self.live = True
         self.received_at = 0.0
+        # Wall clock is what you report; monotonic is what you subtract. An NTP step
+        # between two `received_at` reads can produce a negative interval.
+        self.received_monotonic = 0.0
+        #: This sequence number arrived before, carrying a different block hash.
+        self.reorg = False
 
     @property
     def l1_kind_name(self) -> str:
@@ -465,7 +508,8 @@ def parse_frame(frame: dict[str, Any], decode_txs: bool = True) -> list[FeedMess
     """
     out: list[FeedMessage] = []
     for entry in frame.get("messages") or ():
-        incoming = (entry.get("message") or {}).get("message") or {}
+        wrapper = entry.get("message") or {}
+        incoming = wrapper.get("message") or {}
         header = incoming.get("header") or {}
         l2_msg = incoming.get("l2Msg")
         out.append(
@@ -475,6 +519,9 @@ def parse_frame(frame: dict[str, Any], decode_txs: bool = True) -> list[FeedMess
                 l1_sender=header.get("sender"),
                 timestamp=header.get("timestamp", 0),
                 txs=decode_l2_message(base64.b64decode(l2_msg)) if (l2_msg and decode_txs) else [],
+                block_hash=entry.get("blockHash"),
+                delayed_messages_read=wrapper.get("delayedMessagesRead") or 0,
+                l1_block_number=header.get("blockNumber") or 0,
             )
         )
     return out
@@ -491,8 +538,16 @@ def is_filtered_call(tx_hash: str) -> dict[str, Any]:
     A transaction can appear in the feed and still be voided — included in a block,
     status 0x0, no logs, gas burned. See the README. Send this to an RPC node; a
     non-zero result means the hash is registered and the chain will void it.
+
+    The hash is checked here rather than left to the node: a short or malformed one
+    still ABI-encodes into a perfectly well-formed `eth_call`, and the node would answer
+    it about the wrong slot instead of refusing. A false "not filtered" is the one
+    answer this function must never invent.
     """
-    data = IS_FILTERED_SELECTOR + tx_hash.removeprefix("0x").rjust(64, "0")
+    raw = _unhex(tx_hash, "transaction hash")
+    if len(raw) != 32:
+        raise ValueError(f"not a 32-byte transaction hash: {tx_hash!r} is {len(raw)} bytes")
+    data = IS_FILTERED_SELECTOR + raw.hex()
     return {
         "jsonrpc": "2.0",
         "id": 1,

--- a/src/rhfeed/consume.py
+++ b/src/rhfeed/consume.py
@@ -24,6 +24,17 @@ send *the entire backlog* (`clientconnection.go`, "error finding requested seque
 number in backlog: sending the entire backlog instead"). Re-requesting the last
 seen number is always in range, and costs exactly one duplicate, which is dropped.
 
+**Reorgs.** A re-sent sequence number is not necessarily a duplicate. Nitro has no
+reorg message type at all: `addMessagesAndReorg` re-broadcasts from the reorg point, so
+the replacement arrives under a sequence number you have already seen, carrying a
+different `blockHash`. Comparing that hash is the only detection the protocol offers,
+which is why recent hashes are kept here. A real reorg rewinds the watermark, is
+counted in `stats["reorgs"]`, warns, and arrives with `msg.reorg` set; a true duplicate
+is still dropped silently. Worth knowing that a relay hop destroys this signal —
+`broadcastclients.go` dedups by sequence number on a 10-second window and returns the
+replacement to nobody — so reorg visibility is a reason to read the sequencer feed
+directly even though a relay is the better place to fan out from.
+
 **Sender recovery on the hot path.** Never done here. `tx.sender` is lazy — ask for
 it on the handful of transactions that survive your filter, not on all of them.
 
@@ -87,6 +98,7 @@ class FeedConsumer:
         reconnect_delay: float = 0.5,
         max_reconnect_delay: float = 30.0,
         stall_warning: float = 30.0,
+        reorg_window: int = 1024,
     ) -> None:
         self.url = url
         #: Drop messages that do not carry a good signature from an allowed signer.
@@ -102,6 +114,10 @@ class FeedConsumer:
         #: produces several blocks a second, so silence this long is a fault
         #: somewhere, usually the relay's own upstream. 0 disables the check.
         self.stall_warning = stall_warning
+        #: How many recent block hashes to keep for reorg detection. At ~115 ms a block
+        #: the default covers about two minutes, comfortably past the 10-second window
+        #: within which a relay would have swallowed the replay anyway.
+        self.reorg_window = reorg_window
 
         self.stats = {
             "frames": 0,
@@ -110,11 +126,13 @@ class FeedConsumer:
             "duplicate_messages": 0,
             "unverified_messages": 0,
             "reconnects": 0,
+            "reorgs": 0,
         }
         self._live = False
         self._highest_seq = -1
         self._last_frame_at = 0.0
         self._warned_unverified = False
+        self._hashes: dict[int, str] = {}
 
     @property
     def is_live(self) -> bool:
@@ -219,9 +237,10 @@ class FeedConsumer:
                         async for raw in ws:
                             self.stats["frames"] += 1
                             received = time.time()
-                            self._last_frame_at = time.monotonic()
+                            mono = self._last_frame_at = time.monotonic()
                             for msg in self._frame(_loads(raw), started, decode_backlog):
                                 msg.received_at = received
+                                msg.received_monotonic = mono
                                 yield msg
                 except asyncio.CancelledError:
                     raise
@@ -266,16 +285,57 @@ class FeedConsumer:
         # future drift in that contract into an error rather than a signature checked
         # against the wrong message.
         for entry, msg in zip(entries, messages, strict=True):
-            if msg.seq <= self._highest_seq:
-                self.stats["duplicate_messages"] += 1
-                continue
+            # Verify before the watermark is consulted, not after. Both branches below
+            # can move the watermark — forward for a new message, *backward* for a
+            # reorg — so a message that cannot be trusted must not reach either.
             if self.verify is not None and not self.verify.accepts(entry):
                 self._reject(entry, msg.seq)
                 continue
+            if msg.seq <= self._highest_seq:
+                if not self._is_reorg(msg):
+                    self.stats["duplicate_messages"] += 1
+                    continue
+                # A reorg replaces this sequence number and everything after it, so the
+                # watermark rewinds to just below it and the replacements that follow
+                # are delivered as ordinary new messages.
+                self.stats["reorgs"] += 1
+                msg.reorg = True
+                self._highest_seq = msg.seq - 1
+                _log.warning(
+                    "feed reorg at seq %d: block hash changed from %s to %s. "
+                    "Anything you derived from the old block is now stale",
+                    msg.seq,
+                    self._hashes.get(msg.seq),
+                    msg.block_hash,
+                )
             self._highest_seq = msg.seq
+            self._remember(msg)
             msg.live = live
             self.stats["live_messages" if live else "backlog_messages"] += 1
             yield msg
+
+    def _is_reorg(self, msg: FeedMessage) -> bool:
+        """Whether a re-sent sequence number is a replacement rather than a duplicate.
+
+        Nitro has no reorg message type. `addMessagesAndReorg` simply re-broadcasts from
+        the reorg point, so the same sequence number arrives again carrying a different
+        block hash — that difference is the entire signal, which is why `block_hash` has
+        to be kept rather than decoded and dropped.
+
+        Unknown hash on either side means unknown, so this says no. Better to treat a
+        reorg as a duplicate than to rewind the watermark on a message we cannot compare.
+        """
+        previous = self._hashes.get(msg.seq)
+        return bool(previous and msg.block_hash) and previous != msg.block_hash
+
+    def _remember(self, msg: FeedMessage) -> None:
+        """Record seq -> block hash, keeping the window bounded."""
+        if not msg.block_hash:
+            return
+        self._hashes[msg.seq] = msg.block_hash
+        if len(self._hashes) > self.reorg_window * 2:
+            cutoff = self._highest_seq - self.reorg_window
+            self._hashes = {s: h for s, h in self._hashes.items() if s > cutoff}
 
     def _reject(self, entry: dict, seq: int) -> None:
         """Drop a message that failed verification, without advancing the watermark.

--- a/tests/test_reorg.py
+++ b/tests/test_reorg.py
@@ -1,0 +1,169 @@
+"""Envelope fields the decoder used to drop, and the reorg they make detectable.
+
+A reorg is the one case where a sequence number you have already seen is *not* a
+duplicate. Nitro offers no message type for it, so the only signal is the same sequence
+number arriving with a different block hash — which the consumer can only see if the
+decoder keeps the hash. These two things are tested together because neither is useful
+alone.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+
+import pytest
+
+from rhfeed import FeedConsumer, is_filtered_call, parse_frame
+
+L2MSG = base64.b64encode(b"\x04" + b"\x00" * 8).decode()
+
+
+def entry(seq: int, block_hash: str, delayed: int = 500, l1_block: int = 25_000_000) -> dict:
+    return {
+        "sequenceNumber": seq,
+        "blockHash": block_hash,
+        "message": {
+            "delayedMessagesRead": delayed,
+            "message": {
+                "header": {
+                    "kind": 3,
+                    "sender": "0xa4b000000000000000000073657175656e636572",
+                    "blockNumber": l1_block,
+                    "timestamp": int(time.time()),
+                },
+                "l2Msg": L2MSG,
+            },
+        },
+    }
+
+
+def frame(*entries) -> dict:
+    return {"version": 1, "messages": list(entries)}
+
+
+def hash_of(n: int) -> str:
+    return "0x" + f"{n:02x}" * 32
+
+
+# --------------------------------------------------------------------------- #
+# the fields themselves
+# --------------------------------------------------------------------------- #
+
+
+def test_the_envelope_fields_survive_decoding():
+    """These are signed, so `verify.py` already read them; `codec.py` dropped them."""
+    msg = parse_frame(frame(entry(7, hash_of(0xAB), delayed=78_049, l1_block=25_647_511)))[0]
+    assert msg.block_hash == hash_of(0xAB)
+    assert msg.delayed_messages_read == 78_049
+    assert msg.l1_block_number == 25_647_511
+
+
+def test_the_fields_are_absent_rather_than_wrong_when_the_envelope_omits_them():
+    bare = {
+        "sequenceNumber": 1,
+        "message": {"message": {"header": {"kind": 3, "timestamp": 1}, "l2Msg": L2MSG}},
+    }
+    msg = parse_frame(frame(bare))[0]
+    assert msg.block_hash is None
+    assert msg.delayed_messages_read == 0
+    assert msg.l1_block_number == 0
+
+
+def test_a_delayed_inbox_read_is_visible_as_a_jump():
+    """A jump means the sequencer pulled messages out of the delayed inbox."""
+    consumer = FeedConsumer()
+    seen = [
+        m.delayed_messages_read
+        for e in (entry(1, hash_of(1), delayed=500), entry(2, hash_of(2), delayed=503))
+        for m in consumer._frame(frame(e), time.time(), True)
+    ]
+    assert seen == [500, 503]
+
+
+# --------------------------------------------------------------------------- #
+# reorgs
+# --------------------------------------------------------------------------- #
+
+
+def test_the_same_sequence_number_with_the_same_hash_is_still_a_duplicate():
+    consumer = FeedConsumer()
+    repeated = entry(10, hash_of(1))
+    list(consumer._frame(frame(repeated), time.time(), True))
+    assert list(consumer._frame(frame(repeated), time.time(), True)) == []
+    assert consumer.stats["duplicate_messages"] == 1
+    assert consumer.stats["reorgs"] == 0
+
+
+def test_the_same_sequence_number_with_a_different_hash_is_a_reorg():
+    consumer = FeedConsumer()
+    list(consumer._frame(frame(entry(10, hash_of(1))), time.time(), True))
+    out = list(consumer._frame(frame(entry(10, hash_of(2))), time.time(), True))
+    assert [m.seq for m in out] == [10]
+    assert out[0].reorg is True
+    assert consumer.stats["reorgs"] == 1
+    assert consumer.stats["duplicate_messages"] == 0
+
+
+def test_a_reorg_delivers_the_replacements_that_follow_it():
+    """Nitro re-broadcasts *from* the reorg point, so 11 and 12 come again too."""
+    consumer = FeedConsumer()
+    for seq in (10, 11, 12):
+        list(consumer._frame(frame(entry(seq, hash_of(1))), time.time(), True))
+    replayed = [
+        m.seq
+        for seq in (11, 12)
+        for m in consumer._frame(frame(entry(seq, hash_of(2))), time.time(), True)
+    ]
+    assert replayed == [11, 12]
+    assert consumer.highest_seq == 12
+
+
+def test_an_unverified_message_cannot_force_a_rewind():
+    """The reorg path moves the watermark backwards, so it must sit behind verification."""
+    from rhfeed import MAINNET_VERIFIER
+
+    consumer = FeedConsumer(verify=MAINNET_VERIFIER)
+    consumer._highest_seq = 5_000
+    consumer._hashes[100] = hash_of(1)
+    assert list(consumer._frame(frame(entry(100, hash_of(2))), time.time(), True)) == []
+    assert consumer.highest_seq == 5_000
+    assert consumer.stats["reorgs"] == 0
+
+
+def test_an_uncomparable_replay_is_treated_as_a_duplicate():
+    """No hash on either side means no evidence, and no evidence must not rewind."""
+    consumer = FeedConsumer()
+    bare = {
+        "sequenceNumber": 3,
+        "message": {"message": {"header": {"kind": 3, "timestamp": 1}, "l2Msg": L2MSG}},
+    }
+    list(consumer._frame(frame(bare), time.time(), True))
+    assert list(consumer._frame(frame(bare), time.time(), True)) == []
+    assert consumer.stats["reorgs"] == 0
+    assert consumer.highest_seq == 3
+
+
+def test_the_hash_window_stays_bounded():
+    consumer = FeedConsumer(reorg_window=8)
+    for seq in range(200):
+        list(consumer._frame(frame(entry(seq, hash_of(seq % 251))), time.time(), True))
+    assert len(consumer._hashes) <= consumer.reorg_window * 2
+
+
+# --------------------------------------------------------------------------- #
+# the filter call
+# --------------------------------------------------------------------------- #
+
+
+def test_a_well_formed_hash_builds_the_expected_call():
+    body = is_filtered_call("0x" + "ab" * 32)
+    assert body["params"][0]["data"] == "0x85c733a4" + "ab" * 32
+    assert body["params"][0]["to"].endswith("74")
+
+
+@pytest.mark.parametrize("bad", ["0x", "0xabcd", "0x" + "ab" * 31, "0x" + "ab" * 33, "nonsense"])
+def test_a_malformed_hash_is_refused_rather_than_asked_about(bad):
+    """A short hash still encodes into a valid call, and the node would answer it."""
+    with pytest.raises(ValueError):
+        is_filtered_call(bad)


### PR DESCRIPTION
## What

`parse_frame` read five fields off each envelope and dropped three: `blockHash`, `delayedMessagesRead`, and the parent-chain `blockNumber`. All three were already being parsed by `verify.py` to rebuild the signature preimage, so the data was in hand and thrown away.

## Why it was a correctness bug, not a missing feature

Nitro has no reorg message type. `addMessagesAndReorg` (`arbnode/transaction_streamer.go`) re-broadcasts from the reorg point, so a replacement arrives under a sequence number you have already seen, carrying a **different block hash**. That difference is the entire signal the protocol offers.

`_frame` dropped anything with `seq <= _highest_seq` as a duplicate, so a reorg was silently swallowed and stale state stayed stale — while the README explicitly promised the block hash let you detect exactly this.

## Changes

- `FeedMessage` carries `block_hash`, `delayed_messages_read`, `l1_block_number`.
- `FeedConsumer` keeps a bounded window of recent block hashes (`reorg_window`, default 1024 ≈ two minutes at ~115 ms a block), distinguishes a replacement from a duplicate, rewinds the watermark so the messages *after* the reorg point are delivered too, sets `msg.reorg`, warns once, and counts `stats["reorgs"]`.
- **Verification moved ahead of the watermark check.** The reorg path moves the watermark *backwards*, so an unverified frame must not be able to reach it — otherwise one injected message with an old sequence number and a fresh hash forces a rewind. Covered by a test.
- `received_monotonic` alongside `received_at`; subtracting two wall clocks across an NTP step can produce a negative interval.
- `is_filtered_call` validates the hash is 32 bytes. A short one still ABI-encodes into a perfectly well-formed `eth_call`, and the node answers it about the wrong slot — a false "not filtered" is the one answer that function must never invent.

## Notes

`delayed_messages_read` is worth having on its own: a jump means the sequencer just consumed delayed-inbox messages, which is the on-feed signature of L1 deposits or a force inclusion routing around the sequencer.

Worth knowing that a relay hop destroys reorg visibility regardless of this change — `broadcastclients.go` dedups by sequence number on a 10-second window and never forwards the replacement. Documented in the module docstring.

## Verification

- 122 tests pass (was 107); 15 new in `tests/test_reorg.py`.
- `ruff check` and `ruff format --check` clean.
- Live against mainnet: 300 live messages, all three fields populated, 0 unverified dropped, hash window stayed bounded.

Out of scope, found while testing: breaking out of `live()` early emits `RuntimeError: aclose(): asynchronous generator is already running`. Reproduced identically on `main`, so it predates this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed messages now expose block, delayed-message, and L1 block metadata.
  * Added reorganization detection and replay handling for verified messages.
  * Messages include liveness and receipt timing information.
  * Added configurable tracking limits for reorganization detection.

* **Bug Fixes**
  * Duplicate messages are now distinguished from block reorganizations.
  * Invalid transaction hashes are rejected before compliance checks.

* **Tests**
  * Added coverage for metadata decoding, delayed-message updates, reorganization behavior, and hash validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->