### PR TITLE
docs: correct the claim that a relay verifies its upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ because Robinhood rate-limits **per client, not per connection**, so opening fiv
 sockets yourself splits one client's budget five ways. It's also cheap: 23 MB of
 memory and ~1.6% of a core, nothing written to disk. It is *not* a full node.
 
+Two things a relay does not give you, so you know what you're trading:
+
+- **It verifies nothing.** A relay has no L1 connection, so it cannot check who signed
+  its upstream, and its defaults accept every signature. Pass `--verify` at your end;
+  see [Verify it](#verify-it).
+- **It hides reorgs.** `broadcastclients.go` dedups by sequence number over a
+  10-second window, and a reorg *is* a re-sent sequence number — so the replacement is
+  dropped inside the relay and the signal never reaches your side of it at all. Read
+  the sequencer feed directly (`--feed mainnet`) if reorgs matter to you.
+
 ## Filter it
 
 There is one command and seven flags.
@@ -79,11 +89,15 @@ uv run rhfeed --verify          # drop anything not signed by the sequencer key
 `--to`, `--selector` and `--sender` can each be repeated, and they combine.
 
 `--verify` checks the signature every message carries and drops the ones that fail,
-reporting the count in the summary line even when it is zero. Worth turning on
-whenever the feed is one you don't control — a public endpoint, someone else's relay,
-a capture handed to you. It costs one signature recovery per message and is off by
-default, because the default URL is a relay you run that verified its own upstream
-already. See [Verify it](#verify-it).
+reporting the count in the summary line even when it is zero. It costs one signature
+recovery per message — around 0.1 ms against a feed delivering tens of messages a
+second.
+
+**Turn it on.** It is off by default only for backward compatibility, and the reason
+this README used to give for leaving it off was wrong: a relay you run does *not* verify
+its upstream. The stock `relay` binary verifies nothing at all — see
+[Verify it](#verify-it). So the local-relay case is not the safe case; it is the case
+where nobody has checked.
 
 Not sure what to filter on? `uv run python examples/replay_capture.py` decodes the
 frames bundled for the tests and ranks the contracts, selectors and wallets in them.
@@ -152,9 +166,32 @@ makes by default.
 Worth being clear about what it buys you, since the transport is already `wss`. TLS
 tells you that you reached whatever sits in front of the endpoint. The signature tells
 you the message was produced by the sequencer's key — a claim that survives a
-compromised CDN edge, a proxy of your own, a relay you don't operate, and a capture
-off disk. It says nothing about whether the transaction will succeed; see the next
-section for that.
+compromised CDN edge, a proxy of your own, any relay including one you run yourself,
+and a capture off disk. It says nothing about whether the transaction will succeed; see
+the next section for that.
+
+**A relay does not do this for you.** It is tempting to assume the relay in
+[`docker-compose.yml`](docker-compose.yml) validates its upstream and that a consumer
+behind it can therefore skip the check. It does not, and the defaults are the reason:
+
+- `relay/relay.go` passes `nil` for the `addrVerifier` argument of
+  `NewBroadcastClients` — a relay has no L1 connection, so it cannot resolve who the
+  batch posters are.
+- `DefaultFeedVerifierConfig` in `util/signature/verifier.go` sets
+  `AcceptSequencer: true` **and** `Dangerous.AcceptMissing: true`.
+- Those two combine at `verifier.go`: `if v.config.Dangerous.AcceptMissing &&
+  v.addrVerifier == nil { return nil }` — every signature is accepted, valid or forged.
+
+So `--node.feed.input.verify.accept-sequencer` is inert inside the relay binary, and the
+stock relay performs no effective verification. (Verified against Nitro v3.11.2, the
+image this repo pins.) Tightening it is not a flag flip either: setting
+`accept-missing=false` while `accept-sequencer=true` with no address verifier makes
+`NewVerifier` fail with "cannot read batch poster addresses". A relay that must check
+has to pin `--node.feed.input.verify.allowed-addresses` instead.
+
+The relay is still the right place to fan out from, and it never *weakens* a signature —
+it copies `signatureV2` through verbatim and refuses to re-sign. End-to-end verification
+works precisely because the relay is transparent. Just do the checking at your end.
 
 A message that fails verification is dropped without advancing the sequence watermark,
 so injecting one frame can't make a reconnect skip the real messages behind it. If

--- a/src/rhfeed/consume.py
+++ b/src/rhfeed/consume.py
@@ -27,13 +27,18 @@ seen number is always in range, and costs exactly one duplicate, which is droppe
 **Sender recovery on the hot path.** Never done here. `tx.sender` is lazy — ask for
 it on the handful of transactions that survive your filter, not on all of them.
 
-**Signatures.** Off by default, because the default URL is a relay you run and it
-verified its own upstream. Pass `verify=MAINNET_VERIFIER` when the feed is one you do
-not control — a public endpoint, someone else's relay, a capture off disk — and
-messages that do not carry a good signature from the chain's sequencer key are
-dropped before you see them. A rejected message does not advance the sequence
-watermark, so injecting one cannot make a reconnect skip the real ones behind it. See
-`verify.py` for what the signature covers and what it is worth.
+**Signatures.** Pass `verify=MAINNET_VERIFIER` and messages that do not carry a good
+signature from the chain's sequencer key are dropped before you see them. A rejected
+message does not advance the sequence watermark, so injecting one cannot make a
+reconnect skip the real ones behind it. See `verify.py` for what the signature covers.
+
+Off by default for backward compatibility only. Pointing at a relay you run is *not* a
+reason to skip it: the stock `relay` binary verifies nothing. It passes `nil` for
+`NewBroadcastClients`' `addrVerifier` because it has no L1 connection to resolve batch
+posters with, and `DefaultFeedVerifierConfig` ships `AcceptMissing: true`, so
+`verifier.go` short-circuits every signature to accepted. The relay copies `signatureV2`
+through verbatim and refuses to re-sign, which is what makes end-to-end verification
+work — but it means the checking has to happen here.
 
 **Silence.** A relay that is not running, a relay whose own upstream connection is
 down, a relay still replaying its backlog, and a chain that happens to be quiet all
@@ -90,9 +95,10 @@ class FeedConsumer:
     ) -> None:
         self.url = url
         #: Drop messages that do not carry a good signature from an allowed signer.
-        #: Off by default: it costs an ECDSA recovery per message, and the default URL
-        #: is a relay you run, which verified its own upstream already. Pass
-        #: `MAINNET_VERIFIER` when reading a feed you do not control.
+        #: Off by default for backward compatibility, not because it is unnecessary —
+        #: a relay you run verifies nothing of its own (see the module docstring), so
+        #: passing `MAINNET_VERIFIER` is the right call against any feed, local or not.
+        #: Costs one ECDSA recovery per message, ~0.1 ms.
         self.verify = verify
         self.live_threshold = live_threshold
         self.max_backlog_seconds = max_backlog_seconds

--- a/src/rhfeed/verify.py
+++ b/src/rhfeed/verify.py
@@ -9,10 +9,16 @@ recovery, both local.
 Why bother, given the transport is already `wss`? TLS tells you that you are talking
 to whatever is in front of the endpoint. The signature tells you the message was
 produced by the key that posts this chain's batches to Ethereum — a claim that
-survives a compromised CDN edge, a proxy of your own, a relay you do not operate, and
-a `.jsonl` capture someone hands you. It is also the check a stock Nitro node makes by
-default (`--feed.input.verify.accept-sequencer`), so declining to make it puts you
-strictly behind the software everyone else on the chain is running.
+survives a compromised CDN edge, a proxy of your own, any relay including one you run
+yourself, and a `.jsonl` capture someone hands you. It is also the check a stock Nitro
+*node* makes by default (`--feed.input.verify.accept-sequencer`), so declining to make
+it puts you strictly behind the software everyone else on the chain is running.
+
+Note the emphasis on node. A stock **relay** makes no such check: it has no L1
+connection, so it passes `nil` for `NewBroadcastClients`' `addrVerifier`, and
+`DefaultFeedVerifierConfig` ships `Dangerous.AcceptMissing: true`, which together
+short-circuit every signature to accepted. `accept-sequencer` is inert in the relay
+binary.
 
     from rhfeed import MAINNET_VERIFIER, FeedConsumer
 
@@ -21,8 +27,8 @@ strictly behind the software everyone else on the chain is running.
 
 Cost is one ECDSA recovery per *message*, which is the same order as recovering one
 transaction sender — call it ~0.1 ms, against a feed that delivers tens of messages a
-second. Cheap, but not free, and pointless against a relay you run yourself that
-already verified upstream. So it is opt-in.
+second. Cheap, but not free, which is the only reason it is opt-in rather than the
+default. There is no feed this is pointless against.
 
 **The preimage.** `BroadcastFeedMessage.SignatureHash` in Nitro's
 `broadcaster/message/message.go`. Field order matters, and two details are easy to get


### PR DESCRIPTION
## What

Three places told the reader `--verify` is unnecessary behind a relay they run, because the relay already validated its upstream:

- `README.md`, "Filter it"
- `src/rhfeed/consume.py` module docstring, and the `self.verify` comment
- `src/rhfeed/verify.py` module docstring

None of it is true. This is the one I'd treat as most serious of the batch, because it's a shipping package talking users out of a security check on a false premise.

## The actual behaviour

Read against Nitro **v3.11.2**, the image `docker-compose.yml` pins:

- `relay/relay.go` passes `nil` for the `addrVerifier` argument of `NewBroadcastClients` — a relay has no L1 connection, so it cannot resolve who the batch posters are.
- `DefaultFeedVerifierConfig` (`util/signature/verifier.go`) ships `AcceptSequencer: true` **and** `Dangerous.AcceptMissing: true`.
- Those combine: `if v.config.Dangerous.AcceptMissing && v.addrVerifier == nil { return nil }` — every signature accepted, valid or forged.

So `--node.feed.input.verify.accept-sequencer` is inert inside the relay binary. The local-relay case isn't the safe case, it's the case where nobody checked. Tightening it isn't a flag flip either — `accept-missing=false` with `accept-sequencer=true` and no address verifier makes `NewVerifier` fail with "cannot read batch poster addresses"; a relay that must check has to pin `allowed-addresses`.

Worth being clear the relay is not *bad*: it never weakens a signature, copies `signatureV2` through verbatim, and refuses to re-sign. End-to-end verification is sound precisely because it's transparent. The checking just has to happen at the consumer.

## Also

Documents the second thing a relay doesn't give you — **reorg visibility**. `broadcastclients.go` dedups by sequence number over a 10-second window, and a reorg *is* a re-sent sequence number, so the replacement dies inside the relay.

## Scope

Docs only, no behaviour change. The `verify=` default stays off — flipping it is a behaviour change and deserves its own decision, not a docs PR. The wording now says it's off for backward compatibility and recommends turning it on, rather than justifying it with something untrue.

Deliberately **not** included:

- Anything reframing feed-vs-node timing. My measurement compared a Cloudflare-fronted feed path against a node in a different region, so it measured geography, not protocol — the README's existing note that location matters already covers it.
- The jitter-vs-decode-cost point about the Speed table. That number only earns a README slot once it justifies a design decision, which means it belongs with the connection-racing change, not here.

## Verification

107 tests pass, `ruff check` and `ruff format --check` clean. No remaining instance of the old claim (`grep` over `README.md`, `src/`, `examples/`).

Independent of #2 — branched from `main`, touches no overlapping lines.